### PR TITLE
Add comprehensive test

### DIFF
--- a/tests/EntityFrameworkCore.AuditInterceptor.Tests/EntityFrameworkCore.AuditInterceptor.Tests.csproj
+++ b/tests/EntityFrameworkCore.AuditInterceptor.Tests/EntityFrameworkCore.AuditInterceptor.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EntityFrameworkCore.AuditInterceptor\EntityFrameworkCore.AuditInterceptor.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/EntityFrameworkCore.AuditInterceptor.Tests/Extensions/ServiceCollectionExtensionsTests.cs
+++ b/tests/EntityFrameworkCore.AuditInterceptor.Tests/Extensions/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,109 @@
+using EntityFrameworkCore.AuditInterceptor.Extensions;
+using EntityFrameworkCore.AuditInterceptor.Interfaces;
+using EntityFrameworkCore.AuditInterceptor.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using Xunit;
+
+namespace EntityFrameworkCore.AuditInterceptor.Tests.Extensions
+{
+    public class ServiceCollectionExtensionsTests
+    {
+        [Fact]
+        public void AddAuditInterceptor_RegistersRequiredServices()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddHttpContextAccessor();
+
+            // Act
+            services.AddAuditInterceptor();
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            
+            var currentUserService = serviceProvider.GetService<ICurrentUserService>();
+            Assert.NotNull(currentUserService);
+            Assert.IsType<CurrentUserService>(currentUserService);
+
+            var auditService = serviceProvider.GetService<IAuditService>();
+            Assert.NotNull(auditService);
+            Assert.IsType<AuditService>(auditService);
+        }
+
+        [Fact]
+        public void AddAuditInterceptor_WithOptions_ConfiguresOptions()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddHttpContextAccessor();
+
+            // Act
+            services.AddAuditInterceptor(options =>
+            {
+                options.UserIdClaimType = "custom-claim-type";
+            });
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var auditOptions = serviceProvider.GetRequiredService<AuditOptions>();
+            
+            Assert.Equal("custom-claim-type", auditOptions.UserIdClaimType);
+        }
+
+        [Fact]
+        public void AddAuditInterceptor_WithCustomCurrentUserService_RegistersCustomImplementation()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddHttpContextAccessor();
+            services.AddScoped<ICurrentUserService, CustomCurrentUserService>();
+
+            // Act
+            services.AddAuditInterceptor();
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var currentUserService = serviceProvider.GetRequiredService<ICurrentUserService>();
+            
+            Assert.IsType<CustomCurrentUserService>(currentUserService);
+        }
+
+        [Fact]
+        public void UseAuditInterceptor_AddsInterceptorToDbContextOptions()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            services.AddHttpContextAccessor();
+            services.AddAuditInterceptor();
+            
+            // Act
+            services.AddDbContext<TestDbContext>((sp, options) =>
+            {
+                options.UseInMemoryDatabase("TestDb")
+                       .UseAuditInterceptor(sp);
+            });
+
+            // Assert
+            var serviceProvider = services.BuildServiceProvider();
+            var dbContext = serviceProvider.GetRequiredService<TestDbContext>();
+            
+            // Verify the context was created successfully with the interceptor
+            Assert.NotNull(dbContext);
+        }
+
+        private class CustomCurrentUserService : ICurrentUserService
+        {
+            public string UserId => "custom-user-id";
+        }
+
+        private class TestDbContext : DbContext
+        {
+            public TestDbContext(DbContextOptions<TestDbContext> options) : base(options)
+            {
+            }
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.AuditInterceptor.Tests/Integration/AuditInterceptorIntegrationTests.cs
+++ b/tests/EntityFrameworkCore.AuditInterceptor.Tests/Integration/AuditInterceptorIntegrationTests.cs
@@ -1,0 +1,135 @@
+using EntityFrameworkCore.AuditInterceptor.Extensions;
+using EntityFrameworkCore.AuditInterceptor.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EntityFrameworkCore.AuditInterceptor.Tests.Integration
+{
+    public class AuditInterceptorIntegrationTests
+    {
+        [Fact]
+        public async Task SaveChanges_WithAuditableEntities_AppliesAuditInformation()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            var userId = "test-integration-user";
+            
+            // Configure services
+            services.AddHttpContextAccessor();
+            services.AddScoped<IHttpContextAccessor>(provider => 
+            {
+                var accessor = new HttpContextAccessor();
+                accessor.HttpContext = new DefaultHttpContext
+                {
+                    User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+                    {
+                        new Claim(ClaimTypes.NameIdentifier, userId)
+                    }, "TestAuthentication"))
+                };
+                return accessor;
+            });
+            
+            services.AddAuditInterceptor();
+            services.AddDbContext<TestDbContext>((sp, options) =>
+            {
+                options.UseInMemoryDatabase("IntegrationTestDb")
+                       .UseAuditInterceptor(sp);
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var dbContext = serviceProvider.GetRequiredService<TestDbContext>();
+
+            // Act - Add entity
+            var entity = new TestAuditableEntity { Name = "Test Entity" };
+            dbContext.AuditableEntities.Add(entity);
+            await dbContext.SaveChangesAsync();
+
+            // Assert - Created properties set
+            var savedEntity = await dbContext.AuditableEntities.FindAsync(entity.Id);
+            Assert.Equal(userId, savedEntity.CreatedBy);
+            Assert.NotEqual(default, savedEntity.CreatedOn);
+            Assert.Null(savedEntity.LastModifiedBy);
+            Assert.Equal(default, savedEntity.LastModifiedOn);
+
+            // Act - Update entity
+            savedEntity.Name = "Updated Test Entity";
+            await dbContext.SaveChangesAsync();
+
+            // Assert - Modified properties set
+            var updatedEntity = await dbContext.AuditableEntities.FindAsync(entity.Id);
+            Assert.Equal(userId, updatedEntity.CreatedBy);
+            Assert.NotEqual(default, updatedEntity.CreatedOn);
+            Assert.Equal(userId, updatedEntity.LastModifiedBy);
+            Assert.NotEqual(default, updatedEntity.LastModifiedOn);
+        }
+
+        [Fact]
+        public async Task SaveChanges_WithNonAuditableEntities_DoesNotApplyAuditInformation()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Configure services
+            services.AddHttpContextAccessor();
+            services.AddAuditInterceptor();
+            services.AddDbContext<TestDbContext>((sp, options) =>
+            {
+                options.UseInMemoryDatabase("NonAuditableTestDb")
+                       .UseAuditInterceptor(sp);
+            });
+
+            var serviceProvider = services.BuildServiceProvider();
+            var dbContext = serviceProvider.GetRequiredService<TestDbContext>();
+
+            // Act - Add non-auditable entity
+            var entity = new TestNonAuditableEntity { Name = "Non-Auditable Entity" };
+            dbContext.NonAuditableEntities.Add(entity);
+            await dbContext.SaveChangesAsync();
+
+            // Assert - Entity saved without errors
+            var savedEntity = await dbContext.NonAuditableEntities.FindAsync(entity.Id);
+            Assert.Equal("Non-Auditable Entity", savedEntity.Name);
+        }
+
+        public class TestDbContext : DbContext
+        {
+            public DbSet<TestAuditableEntity> AuditableEntities { get; set; }
+            public DbSet<TestNonAuditableEntity> NonAuditableEntities { get; set; }
+
+            public TestDbContext(DbContextOptions<TestDbContext> options) : base(options)
+            {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<TestAuditableEntity>()
+                    .HasKey(e => e.Id);
+
+                modelBuilder.Entity<TestNonAuditableEntity>()
+                    .HasKey(e => e.Id);
+            }
+        }
+
+        public class TestAuditableEntity : IAuditable
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string CreatedBy { get; set; }
+            public DateTime CreatedOn { get; set; }
+            public string LastModifiedBy { get; set; }
+            public DateTime LastModifiedOn { get; set; }
+        }
+
+        public class TestNonAuditableEntity
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.AuditInterceptor.Tests/Services/AuditServiceTests.cs
+++ b/tests/EntityFrameworkCore.AuditInterceptor.Tests/Services/AuditServiceTests.cs
@@ -1,0 +1,162 @@
+using EntityFrameworkCore.AuditInterceptor.Interfaces;
+using EntityFrameworkCore.AuditInterceptor.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Update;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace EntityFrameworkCore.AuditInterceptor.Tests.Services
+{
+    public class AuditServiceTests
+    {
+        private readonly Mock<ICurrentUserService> _currentUserServiceMock;
+        private readonly AuditService _auditService;
+
+        public AuditServiceTests()
+        {
+            _currentUserServiceMock = new Mock<ICurrentUserService>();
+            _currentUserServiceMock.Setup(x => x.UserId).Returns("test-user-id");
+            _auditService = new AuditService(_currentUserServiceMock.Object);
+        }
+
+        [Fact]
+        public void ApplyAuditInformation_WhenEntityIsAuditable_SetsCreatedProperties()
+        {
+            // Arrange
+            var mockEntity = new TestAuditableEntity();
+            var mockEntry = CreateMockEntityEntry(mockEntity, EntityState.Added);
+            var entries = new List<EntityEntry> { mockEntry.Object };
+
+            // Act
+            _auditService.ApplyAuditInformation(entries);
+
+            // Assert
+            Assert.Equal("test-user-id", mockEntity.CreatedBy);
+            Assert.NotEqual(default, mockEntity.CreatedOn);
+            Assert.Null(mockEntity.LastModifiedBy);
+            Assert.Equal(default, mockEntity.LastModifiedOn);
+        }
+
+        [Fact]
+        public void ApplyAuditInformation_WhenEntityIsAuditableAndModified_SetsModifiedProperties()
+        {
+            // Arrange
+            var mockEntity = new TestAuditableEntity
+            {
+                CreatedBy = "original-creator",
+                CreatedOn = DateTime.UtcNow.AddDays(-1)
+            };
+            var mockEntry = CreateMockEntityEntry(mockEntity, EntityState.Modified);
+            var entries = new List<EntityEntry> { mockEntry.Object };
+
+            // Act
+            _auditService.ApplyAuditInformation(entries);
+
+            // Assert
+            Assert.Equal("original-creator", mockEntity.CreatedBy);
+            Assert.NotEqual(default, mockEntity.CreatedOn);
+            Assert.Equal("test-user-id", mockEntity.LastModifiedBy);
+            Assert.NotEqual(default, mockEntity.LastModifiedOn);
+        }
+
+        [Fact]
+        public void ApplyAuditInformation_WhenEntityIsNotAuditable_DoesNotSetProperties()
+        {
+            // Arrange
+            var mockEntity = new TestNonAuditableEntity();
+            var mockEntry = CreateMockEntityEntry(mockEntity, EntityState.Added);
+            var entries = new List<EntityEntry> { mockEntry.Object };
+
+            // Act
+            _auditService.ApplyAuditInformation(entries);
+
+            // Assert
+            // No exception should be thrown, and no properties modified
+        }
+
+        [Fact]
+        public void ApplyAuditInformation_WithMultipleEntities_HandlesEachCorrectly()
+        {
+            // Arrange
+            var mockAddedEntity = new TestAuditableEntity();
+            var mockModifiedEntity = new TestAuditableEntity
+            {
+                CreatedBy = "original-creator",
+                CreatedOn = DateTime.UtcNow.AddDays(-1)
+            };
+            var mockNonAuditableEntity = new TestNonAuditableEntity();
+
+            var mockAddedEntry = CreateMockEntityEntry(mockAddedEntity, EntityState.Added);
+            var mockModifiedEntry = CreateMockEntityEntry(mockModifiedEntity, EntityState.Modified);
+            var mockNonAuditableEntry = CreateMockEntityEntry(mockNonAuditableEntity, EntityState.Added);
+
+            var entries = new List<EntityEntry> 
+            { 
+                mockAddedEntry.Object, 
+                mockModifiedEntry.Object,
+                mockNonAuditableEntry.Object
+            };
+
+            // Act
+            _auditService.ApplyAuditInformation(entries);
+
+            // Assert
+            Assert.Equal("test-user-id", mockAddedEntity.CreatedBy);
+            Assert.NotEqual(default, mockAddedEntity.CreatedOn);
+            Assert.Null(mockAddedEntity.LastModifiedBy);
+            Assert.Equal(default, mockAddedEntity.LastModifiedOn);
+
+            Assert.Equal("original-creator", mockModifiedEntity.CreatedBy);
+            Assert.Equal("test-user-id", mockModifiedEntity.LastModifiedBy);
+            Assert.NotEqual(default, mockModifiedEntity.LastModifiedOn);
+        }
+
+        [Fact]
+        public void ApplyAuditInformation_WhenUserIdIsNull_UsesSystemUser()
+        {
+            // Arrange
+            _currentUserServiceMock.Setup(x => x.UserId).Returns((string)null);
+            var auditService = new AuditService(_currentUserServiceMock.Object);
+            
+            var mockEntity = new TestAuditableEntity();
+            var mockEntry = CreateMockEntityEntry(mockEntity, EntityState.Added);
+            var entries = new List<EntityEntry> { mockEntry.Object };
+
+            // Act
+            auditService.ApplyAuditInformation(entries);
+
+            // Assert
+            Assert.Equal("System", mockEntity.CreatedBy);
+            Assert.NotEqual(default, mockEntity.CreatedOn);
+        }
+
+        private Mock<EntityEntry> CreateMockEntityEntry<TEntity>(TEntity entity, EntityState state) where TEntity : class
+        {
+            var mockEntry = new Mock<EntityEntry>(MockBehavior.Default);
+            mockEntry.Setup(e => e.Entity).Returns(entity);
+            mockEntry.Setup(e => e.State).Returns(state);
+            return mockEntry;
+        }
+
+        private class TestAuditableEntity : IAuditable
+        {
+            public string CreatedBy { get; set; }
+            public DateTime CreatedOn { get; set; }
+            public string LastModifiedBy { get; set; }
+            public DateTime LastModifiedOn { get; set; }
+        }
+
+        private class TestNonAuditableEntity
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/tests/EntityFrameworkCore.AuditInterceptor.Tests/Services/CurrentUserServiceTests.cs
+++ b/tests/EntityFrameworkCore.AuditInterceptor.Tests/Services/CurrentUserServiceTests.cs
@@ -1,0 +1,64 @@
+using EntityFrameworkCore.AuditInterceptor.Services;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using System.Security.Claims;
+using Xunit;
+
+namespace EntityFrameworkCore.AuditInterceptor.Tests.Services
+{
+    public class CurrentUserServiceTests
+    {
+        [Fact]
+        public void UserId_WhenUserIsAuthenticated_ReturnsNameIdentifierClaim()
+        {
+            // Arrange
+            var userId = "test-user-id";
+            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+            var claimsPrincipalMock = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, userId)
+            }, "TestAuthentication"));
+
+            httpContextAccessorMock.Setup(x => x.HttpContext.User).Returns(claimsPrincipalMock);
+            var currentUserService = new CurrentUserService(httpContextAccessorMock.Object);
+
+            // Act
+            var result = currentUserService.UserId;
+
+            // Assert
+            Assert.Equal(userId, result);
+        }
+
+        [Fact]
+        public void UserId_WhenUserIsNotAuthenticated_ReturnsNull()
+        {
+            // Arrange
+            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+            var claimsPrincipalMock = new ClaimsPrincipal(new ClaimsIdentity());
+
+            httpContextAccessorMock.Setup(x => x.HttpContext.User).Returns(claimsPrincipalMock);
+            var currentUserService = new CurrentUserService(httpContextAccessorMock.Object);
+
+            // Act
+            var result = currentUserService.UserId;
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void UserId_WhenHttpContextIsNull_ReturnsNull()
+        {
+            // Arrange
+            var httpContextAccessorMock = new Mock<IHttpContextAccessor>();
+            httpContextAccessorMock.Setup(x => x.HttpContext).Returns((HttpContext)null);
+            var currentUserService = new CurrentUserService(httpContextAccessorMock.Object);
+
+            // Act
+            var result = currentUserService.UserId;
+
+            // Assert
+            Assert.Null(result);
+        }
+    }
+}


### PR DESCRIPTION
# Comprehensive Test Suite for EntityFrameworkCore.AuditInterceptor

This PR adds a complete test suite for the EntityFrameworkCore.AuditInterceptor package. The test suite includes:

## Unit Tests
- **AuditServiceTests**: Tests for the audit service that applies audit information to entities
- **CurrentUserServiceTests**: Tests for the service that retrieves the current user ID
- **ServiceCollectionExtensionsTests**: Tests for the DI extension methods

## Integration Tests
- **AuditInterceptorIntegrationTests**: End-to-end tests that verify the complete audit functionality with an in-memory database

The tests cover various scenarios including:
- Creating and modifying auditable entities
- Handling non-auditable entities
- Edge cases like null user IDs
- Custom configurations and service registrations

All tests use xUnit with Moq for mocking and the EF Core in-memory provider for database testing.